### PR TITLE
Show Data Directory Hierarchy as general monospace code

### DIFF
--- a/image-data-schema.md
+++ b/image-data-schema.md
@@ -19,7 +19,7 @@
 [The Paper](https://www.nature.com/articles/s41592-021-01326-w)
 
 ## Data Directory Hierarchy
-```bash
+```
  {SAMPLE_ID}                                            (e.g. BB001)
  ├── VISoR_Raw_Images
  |   └── Slice_{SLICE_INDEX}.zarr                       (1-based)


### PR DESCRIPTION
Changed markdown make from "``` bash" to "```".